### PR TITLE
Filter hreflang

### DIFF
--- a/src/inc/Multilingual_Press.php
+++ b/src/inc/Multilingual_Press.php
@@ -10,6 +10,9 @@
  */
 class Multilingual_Press {
 
+    const HREFLANG_TYPE_HTTP_HEADER = 1;
+    const HREFLANG_TYPE_HTML_HEAD = 2;
+
 	/**
 	 * The linked elements table
 	 *
@@ -408,15 +411,15 @@ class Multilingual_Press {
 
 		/**
 		 * Filters the used output methods for the hreflang links.
-		 * Possible values are 'header' and 'html'.
+		 * Possible values are Multilingual_Press::HREFLANG_TYPE_HTTP_HEADER and Multilingual_Press::HREFLANG_TYPE_HTML_HEAD.
 		 *
 		 * @since 2.7.0
 		 *
-		 * @param String[] The used output methods.
+		 * @param int The used output methods.
 		 */
-		$output_methods = apply_filters( 'multilingualpress.hreflang_output_method', array( 'header', 'html' ) );
-		
-		if ( in_array( 'header', $output_methods ) ) {
+		$output_methods = apply_filters( 'multilingualpress.hreflang_type', self::HREFLANG_TYPE_HTTP_HEADER | self::HREFLANG_TYPE_HTML_HEAD );
+
+		if ( $output_methods & self::HREFLANG_TYPE_HTTP_HEADER ) {
 			add_action(
 				'template_redirect',
 				array(
@@ -425,7 +428,7 @@ class Multilingual_Press {
 				)
 			);
 		}
-		if ( in_array( 'html', $output_methods ) ) {
+		if ( $output_methods & self::HREFLANG_TYPE_HTML_HEAD ) {
 			add_action(
 				'wp_head',
 				array(

--- a/src/inc/Multilingual_Press.php
+++ b/src/inc/Multilingual_Press.php
@@ -419,7 +419,7 @@ class Multilingual_Press {
 			Mlp_Hreflang_Header_Output::HREFLANG_TYPE_HTTP_HEADER | Mlp_Hreflang_Header_Output::HREFLANG_TYPE_HTML_HEAD
 		);
 
-		if ( $output_methods & self::HREFLANG_TYPE_HTTP_HEADER ) {
+		if ( $output_methods & Mlp_Hreflang_Header_Output::HREFLANG_TYPE_HTTP_HEADER ) {
 			add_action(
 				'template_redirect',
 				array(
@@ -428,7 +428,7 @@ class Multilingual_Press {
 				)
 			);
 		}
-		if ( $output_methods & self::HREFLANG_TYPE_HTML_HEAD ) {
+		if ( $output_methods & Mlp_Hreflang_Header_Output::HREFLANG_TYPE_HTML_HEAD ) {
 			add_action(
 				'wp_head',
 				array(

--- a/src/inc/Multilingual_Press.php
+++ b/src/inc/Multilingual_Press.php
@@ -405,20 +405,35 @@ class Multilingual_Press {
 
 		// frontend-hooks
 		$hreflang = new Mlp_Hreflang_Header_Output( $this->plugin_data->get( 'language_api' ) );
-		add_action(
-			'template_redirect',
-			array (
-				$hreflang,
-				'http_header'
-			)
-		);
-		add_action(
-			'wp_head',
-			array (
-				$hreflang,
-				'wp_head'
-			)
-		);
+
+		/**
+		 * Filters the used output methods for the hreflang links.
+		 * Possible values are 'header' and 'html'.
+		 *
+		 * @since 2.7.0
+		 *
+		 * @param String[] The used output methods.
+		 */
+		$output_methods = apply_filters( 'multilingualpress.hreflang_output_method', [ 'header', 'html' ] );
+		
+		if ( in_array( 'header', $output_methods ) ) {
+			add_action(
+				'template_redirect',
+				array(
+					$hreflang,
+					'http_header'
+				)
+			);
+		}
+		if ( in_array( 'html', $output_methods ) ) {
+			add_action(
+				'wp_head',
+				array(
+					$hreflang,
+					'wp_head'
+				)
+			);
+		}
 	}
 
 	/**

--- a/src/inc/Multilingual_Press.php
+++ b/src/inc/Multilingual_Press.php
@@ -414,7 +414,7 @@ class Multilingual_Press {
 		 *
 		 * @param String[] The used output methods.
 		 */
-		$output_methods = apply_filters( 'multilingualpress.hreflang_output_method', [ 'header', 'html' ] );
+		$output_methods = apply_filters( 'multilingualpress.hreflang_output_method', array( 'header', 'html' ) );
 		
 		if ( in_array( 'header', $output_methods ) ) {
 			add_action(

--- a/src/inc/Multilingual_Press.php
+++ b/src/inc/Multilingual_Press.php
@@ -406,36 +406,24 @@ class Multilingual_Press {
 		// frontend-hooks
 		$hreflang = new Mlp_Hreflang_Header_Output( $this->plugin_data->get( 'language_api' ) );
 
+		$hreflang_type = Mlp_Hreflang_Header_Output::TYPE_HTTP_HEADER | Mlp_Hreflang_Header_Output::TYPE_HTML_LINK_TAG;
 		/**
-		 * Filters the used output methods for the hreflang links.
-		 * Possible values are Mlp_Hreflang_Header_Output::HREFLANG_TYPE_HTTP_HEADER and Mlp_Hreflang_Header_Output::HREFLANG_TYPE_HTML_HEAD.
+		 * Filters the output type for the hreflang links.
+		 *
+		 * The type is a bitmask with possible (partial) values Mlp_Hreflang_Header_Output::TYPE_HTTP_HEADER and Mlp_Hreflang_Header_Output::TYPE_HTML_LINK_TAG.
 		 *
 		 * @since 2.7.0
 		 *
-		 * @param int The used output methods.
+		 * @param int $hreflang_type The output type for the hreflang links.
 		 */
-		$output_methods = apply_filters(
-			'multilingualpress.hreflang_type',
-			Mlp_Hreflang_Header_Output::HREFLANG_TYPE_HTTP_HEADER | Mlp_Hreflang_Header_Output::HREFLANG_TYPE_HTML_HEAD
-		);
+		$hreflang_type = absint( apply_filters( 'multilingualpress.hreflang_type', $hreflang_type ) );
 
-		if ( $output_methods & Mlp_Hreflang_Header_Output::HREFLANG_TYPE_HTTP_HEADER ) {
-			add_action(
-				'template_redirect',
-				array(
-					$hreflang,
-					'http_header'
-				)
-			);
+		if ( $hreflang_type & Mlp_Hreflang_Header_Output::TYPE_HTTP_HEADER ) {
+			add_action( 'template_redirect', array( $hreflang, 'http_header' ), 11 );
 		}
-		if ( $output_methods & Mlp_Hreflang_Header_Output::HREFLANG_TYPE_HTML_HEAD ) {
-			add_action(
-				'wp_head',
-				array(
-					$hreflang,
-					'wp_head'
-				)
-			);
+
+		if ( $hreflang_type & Mlp_Hreflang_Header_Output::TYPE_HTML_LINK_TAG ) {
+			add_action( 'wp_head', array( $hreflang, 'wp_head' ) );
 		}
 	}
 

--- a/src/inc/Multilingual_Press.php
+++ b/src/inc/Multilingual_Press.php
@@ -10,9 +10,6 @@
  */
 class Multilingual_Press {
 
-    const HREFLANG_TYPE_HTTP_HEADER = 1;
-    const HREFLANG_TYPE_HTML_HEAD = 2;
-
 	/**
 	 * The linked elements table
 	 *
@@ -411,13 +408,16 @@ class Multilingual_Press {
 
 		/**
 		 * Filters the used output methods for the hreflang links.
-		 * Possible values are Multilingual_Press::HREFLANG_TYPE_HTTP_HEADER and Multilingual_Press::HREFLANG_TYPE_HTML_HEAD.
+		 * Possible values are Mlp_Hreflang_Header_Output::HREFLANG_TYPE_HTTP_HEADER and Mlp_Hreflang_Header_Output::HREFLANG_TYPE_HTML_HEAD.
 		 *
 		 * @since 2.7.0
 		 *
 		 * @param int The used output methods.
 		 */
-		$output_methods = apply_filters( 'multilingualpress.hreflang_type', self::HREFLANG_TYPE_HTTP_HEADER | self::HREFLANG_TYPE_HTML_HEAD );
+		$output_methods = apply_filters(
+			'multilingualpress.hreflang_type',
+			Mlp_Hreflang_Header_Output::HREFLANG_TYPE_HTTP_HEADER | Mlp_Hreflang_Header_Output::HREFLANG_TYPE_HTML_HEAD
+		);
 
 		if ( $output_methods & self::HREFLANG_TYPE_HTTP_HEADER ) {
 			add_action(

--- a/src/inc/hreflang-header/Mlp_Hreflang_Header_Output.php
+++ b/src/inc/hreflang-header/Mlp_Hreflang_Header_Output.php
@@ -41,16 +41,6 @@ class Mlp_Hreflang_Header_Output {
 		}
 
 		$translations = $this->get_translations();
-
-		/**
-		 * Filters the available translations before outputting their hreflang links.
-		 *
-		 * @since 2.7.0
-		 *
-		 * @param Mlp_Translation[] $translations The available translations for the current page.
-		 */
-		$translations = apply_filters( 'multilingualpress.hreflang_translations', $translations );
-
 		if ( ! $translations ) {
 			return;
 		}
@@ -87,16 +77,6 @@ class Mlp_Hreflang_Header_Output {
 		}
 
 		$translations = $this->get_translations();
-
-		/**
-		 * Filters the available translations before outputting their hreflang links.
-		 *
-		 * @since 2.7.0
-		 *
-		 * @param Mlp_Translation[] $translations The available translations for the current page.
-		 */
-		$translations = apply_filters( 'multilingualpress.hreflang_translations', $translations );
-
 		if ( ! $translations ) {
 			return;
 		}
@@ -155,6 +135,15 @@ class Mlp_Hreflang_Header_Output {
 				$this->translations[ $language->get_name( 'http' ) ] = $url;
 			}
 		}
+
+		/**
+		 * Filters the available translations before outputting their hreflang links.
+		 *
+		 * @since 2.7.0
+		 *
+		 * @param string[] $translations The available translations for the current page.
+		 */
+		$this->translations = apply_filters( 'multilingualpress.hreflang_translations', $this->translations );
 
 		return $this->translations;
 	}

--- a/src/inc/hreflang-header/Mlp_Hreflang_Header_Output.php
+++ b/src/inc/hreflang-header/Mlp_Hreflang_Header_Output.php
@@ -7,6 +7,9 @@
  */
 class Mlp_Hreflang_Header_Output {
 
+	const HREFLANG_TYPE_HTTP_HEADER = 1;
+	const HREFLANG_TYPE_HTML_HEAD = 2;
+
 	/**
 	 * @var Mlp_Language_Api_Interface
 	 */

--- a/src/inc/hreflang-header/Mlp_Hreflang_Header_Output.php
+++ b/src/inc/hreflang-header/Mlp_Hreflang_Header_Output.php
@@ -7,8 +7,23 @@
  */
 class Mlp_Hreflang_Header_Output {
 
-	const HREFLANG_TYPE_HTTP_HEADER = 1;
-	const HREFLANG_TYPE_HTML_HEAD = 2;
+	/**
+	 * Output type.
+	 *
+	 * @since 2.7.0
+	 *
+	 * @var int
+	 */
+	const TYPE_HTTP_HEADER = 1;
+
+	/**
+	 * Output type.
+	 *
+	 * @since 2.7.0
+	 *
+	 * @var int
+	 */
+	const TYPE_HTML_LINK_TAG = 2;
 
 	/**
 	 * @var Mlp_Language_Api_Interface
@@ -140,11 +155,11 @@ class Mlp_Hreflang_Header_Output {
 		}
 
 		/**
-		 * Filters the available translations before outputting their hreflang links.
+		 * Filters the available translations to be used for hreflang links.
 		 *
 		 * @since 2.7.0
 		 *
-		 * @param string[] $translations The available translations for the current page.
+		 * @param string[] $translations The available translations to be used for hreflang links.
 		 */
 		$this->translations = apply_filters( 'multilingualpress.hreflang_translations', $this->translations );
 

--- a/src/inc/hreflang-header/Mlp_Hreflang_Header_Output.php
+++ b/src/inc/hreflang-header/Mlp_Hreflang_Header_Output.php
@@ -41,6 +41,16 @@ class Mlp_Hreflang_Header_Output {
 		}
 
 		$translations = $this->get_translations();
+
+		/**
+		 * Filters the available translations before outputting their hreflang links.
+		 *
+		 * @since 2.7.0
+		 *
+		 * @param Mlp_Translation[] $translations The available translations for the current page.
+		 */
+		$translations = apply_filters( 'multilingualpress.hreflang_translations', $translations );
+
 		if ( ! $translations ) {
 			return;
 		}
@@ -77,6 +87,16 @@ class Mlp_Hreflang_Header_Output {
 		}
 
 		$translations = $this->get_translations();
+
+		/**
+		 * Filters the available translations before outputting their hreflang links.
+		 *
+		 * @since 2.7.0
+		 *
+		 * @param Mlp_Translation[] $translations The available translations for the current page.
+		 */
+		$translations = apply_filters( 'multilingualpress.hreflang_translations', $translations );
+
 		if ( ! $translations ) {
 			return;
 		}


### PR DESCRIPTION
<!--
Thanks for contributing&mdash;you rock!

Please note:
- These comments won't show up when you submit the pull request.
- Please make sure your changes respect the WordPress Coding Standards:
  - https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- In case you introduced a new action or filter hook, please also include inline documentation:
  - https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/
- Please create tests, if you can.
-->


This pull request fixes issue #266.

#### What's Included in This Pull Request

* Two new filters
  * `multilingualpress.hreflang_output_method` Filters the used output methods for the hreflang links, so either the html or header output can be disabled. Both methods (html and headers) are enabled by default. 
  * `multilingualpress.hreflang_translations` Filters the available translations before outputting their hreflang links, so the hreflang links can be altered with a single filter. For example, with this filter a 'x-default' could be added easily.
