### PR TITLE
Fix Restrict Trasher to active post types. #215

### DIFF
--- a/src/Module/Trasher/ServiceProvider.php
+++ b/src/Module/Trasher/ServiceProvider.php
@@ -9,6 +9,7 @@ use Inpsyde\MultilingualPress\Module\ModuleServiceProvider;
 use Inpsyde\MultilingualPress\Module\Module;
 use Inpsyde\MultilingualPress\Module\ModuleManager;
 use Inpsyde\MultilingualPress\Service\Container;
+use Inpsyde\MultilingualPress\Translation\Post\ActivePostTypes;
 
 /**
  * Module service provider.
@@ -34,11 +35,17 @@ final class ServiceProvider implements ModuleServiceProvider {
 			return new WPNonce( 'save_trasher_setting' );
 		};
 
+		$container['multilingualpress.active_post_types'] = function () {
+
+			return new ActivePostTypes();
+		};
+
 		$container['multilingualpress.trasher'] = function ( Container $container ) {
 
 			return new Trasher(
 				$container['multilingualpress.trasher_setting_repository'],
-				$container['multilingualpress.content_relations']
+				$container['multilingualpress.content_relations'],
+				$container['multilingualpress.active_post_types']
 			);
 		};
 
@@ -53,7 +60,8 @@ final class ServiceProvider implements ModuleServiceProvider {
 				$container['multilingualpress.trasher_setting_repository'],
 				$container['multilingualpress.content_relations'],
 				$container['multilingualpress.server_request'],
-				$container['multilingualpress.save_trasher_setting_nonce']
+				$container['multilingualpress.save_trasher_setting_nonce'],
+				$container['multilingualpress.active_post_types']
 			);
 		};
 
@@ -61,7 +69,8 @@ final class ServiceProvider implements ModuleServiceProvider {
 
 			return new TrasherSettingView(
 				$container['multilingualpress.trasher_setting_repository'],
-				$container['multilingualpress.save_trasher_setting_nonce']
+				$container['multilingualpress.save_trasher_setting_nonce'],
+				$container['multilingualpress.active_post_types']
 			);
 		};
 	}

--- a/src/Module/Trasher/ServiceProvider.php
+++ b/src/Module/Trasher/ServiceProvider.php
@@ -9,7 +9,6 @@ use Inpsyde\MultilingualPress\Module\ModuleServiceProvider;
 use Inpsyde\MultilingualPress\Module\Module;
 use Inpsyde\MultilingualPress\Module\ModuleManager;
 use Inpsyde\MultilingualPress\Service\Container;
-use Inpsyde\MultilingualPress\Translation\Post\ActivePostTypes;
 
 /**
  * Module service provider.
@@ -33,11 +32,6 @@ final class ServiceProvider implements ModuleServiceProvider {
 		$container['multilingualpress.save_trasher_setting_nonce'] = function () {
 
 			return new WPNonce( 'save_trasher_setting' );
-		};
-
-		$container['multilingualpress.active_post_types'] = function () {
-
-			return new ActivePostTypes();
 		};
 
 		$container['multilingualpress.trasher'] = function ( Container $container ) {

--- a/src/Module/Trasher/Trasher.php
+++ b/src/Module/Trasher/Trasher.php
@@ -17,6 +17,11 @@ use Inpsyde\MultilingualPress\Translation\Post\ActivePostTypes;
 class Trasher {
 
 	/**
+	 * @var ActivePostTypes
+	 */
+	private $active_post_types;
+
+	/**
 	 * @var ContentRelations
 	 */
 	private $content_relations;
@@ -32,18 +37,13 @@ class Trasher {
 	private static $trashing_related_posts = false;
 
 	/**
-	 * @var ActivePostTypes
-	 */
-	private $active_post_types;
-
-	/**
 	 * Constructor. Sets up the properties.
 	 *
 	 * @since 3.0.0
 	 *
 	 * @param TrasherSettingRepository $setting_repository Trasher setting repository object.
 	 * @param ContentRelations         $content_relations  Content relations API object.
-	 * @param ActivePostTypes          $active_post_types  ActivePostTypes object.
+	 * @param ActivePostTypes          $active_post_types  Active post types storage object.
 	 */
 	public function __construct(
 		TrasherSettingRepository $setting_repository,
@@ -70,7 +70,7 @@ class Trasher {
 	 */
 	public function trash_related_posts( $post_id ): int {
 
-		if ( ! $this->active_post_types->includes( get_post_type( (int) $post_id ) ) ) {
+		if ( ! $this->active_post_types->includes( (string) get_post_type( $post_id ) ) ) {
 			return 0;
 		}
 

--- a/src/Module/Trasher/Trasher.php
+++ b/src/Module/Trasher/Trasher.php
@@ -6,6 +6,7 @@ namespace Inpsyde\MultilingualPress\Module\Trasher;
 
 use Inpsyde\MultilingualPress\API\ContentRelations;
 use Inpsyde\MultilingualPress\Common\NetworkState;
+use Inpsyde\MultilingualPress\Translation\Post\ActivePostTypes;
 
 /**
  * Post trasher.
@@ -31,18 +32,30 @@ class Trasher {
 	private static $trashing_related_posts = false;
 
 	/**
+	 * @var ActivePostTypes
+	 */
+	private $active_post_types;
+
+	/**
 	 * Constructor. Sets up the properties.
 	 *
 	 * @since 3.0.0
 	 *
 	 * @param TrasherSettingRepository $setting_repository Trasher setting repository object.
 	 * @param ContentRelations         $content_relations  Content relations API object.
+	 * @param ActivePostTypes          $active_post_types  ActivePostTypes object.
 	 */
-	public function __construct( TrasherSettingRepository $setting_repository, ContentRelations $content_relations ) {
+	public function __construct(
+		TrasherSettingRepository $setting_repository,
+		ContentRelations $content_relations,
+		ActivePostTypes $active_post_types
+	) {
 
 		$this->setting_repository = $setting_repository;
 
 		$this->content_relations = $content_relations;
+
+		$this->active_post_types = $active_post_types;
 	}
 
 	/**
@@ -56,6 +69,10 @@ class Trasher {
 	 * @return int The number of related posts trashed.
 	 */
 	public function trash_related_posts( $post_id ): int {
+
+		if ( ! $this->active_post_types->includes( get_post_type( (int) $post_id ) ) ) {
+			return 0;
+		}
 
 		if ( self::$trashing_related_posts || ! $this->setting_repository->get_setting( (int) $post_id ) ) {
 			return 0;

--- a/src/Module/Trasher/TrasherSettingUpdater.php
+++ b/src/Module/Trasher/TrasherSettingUpdater.php
@@ -19,6 +19,11 @@ use Inpsyde\MultilingualPress\Translation\Post\ActivePostTypes;
 class TrasherSettingUpdater {
 
 	/**
+	 * @var ActivePostTypes
+	 */
+	private $active_post_types;
+
+	/**
 	 * @var ContentRelations
 	 */
 	private $content_relations;
@@ -39,11 +44,6 @@ class TrasherSettingUpdater {
 	private $setting_repository;
 
 	/**
-	 * @var ActivePostTypes
-	 */
-	private $active_post_types;
-
-	/**
 	 * Constructor. Sets up the properties.
 	 *
 	 * @since 3.0.0
@@ -52,7 +52,7 @@ class TrasherSettingUpdater {
 	 * @param ContentRelations         $content_relations  Content relations API object.
 	 * @param Request                  $request            HTTP request object.
 	 * @param Nonce                    $nonce              Nonce object.
-	 * @param ActivePostTypes          $active_post_types  ActivePostTypes object.
+	 * @param ActivePostTypes          $active_post_types  Active post types storage object.
 	 */
 	public function __construct(
 		TrasherSettingRepository $setting_repository,
@@ -86,11 +86,11 @@ class TrasherSettingUpdater {
 	 */
 	public function update_settings( $post_id, \WP_Post $post ): int {
 
-		if ( ! $this->nonce->is_valid() ) {
+		if ( ! $this->active_post_types->includes( (string) $post->post_type ) ) {
 			return 0;
 		}
 
-		if ( ! $this->active_post_types->includes( $post->post_type ) ) {
+		if ( ! $this->nonce->is_valid() ) {
 			return 0;
 		}
 

--- a/src/Module/Trasher/TrasherSettingUpdater.php
+++ b/src/Module/Trasher/TrasherSettingUpdater.php
@@ -8,6 +8,7 @@ use Inpsyde\MultilingualPress\API\ContentRelations;
 use Inpsyde\MultilingualPress\Common\HTTP\Request;
 use Inpsyde\MultilingualPress\Common\NetworkState;
 use Inpsyde\MultilingualPress\Common\Nonce\Nonce;
+use Inpsyde\MultilingualPress\Translation\Post\ActivePostTypes;
 
 /**
  * Trasher setting updater.
@@ -38,6 +39,11 @@ class TrasherSettingUpdater {
 	private $setting_repository;
 
 	/**
+	 * @var ActivePostTypes
+	 */
+	private $active_post_types;
+
+	/**
 	 * Constructor. Sets up the properties.
 	 *
 	 * @since 3.0.0
@@ -46,12 +52,14 @@ class TrasherSettingUpdater {
 	 * @param ContentRelations         $content_relations  Content relations API object.
 	 * @param Request                  $request            HTTP request object.
 	 * @param Nonce                    $nonce              Nonce object.
+	 * @param ActivePostTypes          $active_post_types  ActivePostTypes object.
 	 */
 	public function __construct(
 		TrasherSettingRepository $setting_repository,
 		ContentRelations $content_relations,
 		Request $request,
-		Nonce $nonce
+		Nonce $nonce,
+		ActivePostTypes $active_post_types
 	) {
 
 		$this->setting_repository = $setting_repository;
@@ -61,6 +69,8 @@ class TrasherSettingUpdater {
 		$this->request = $request;
 
 		$this->nonce = $nonce;
+
+		$this->active_post_types = $active_post_types;
 	}
 
 	/**
@@ -77,6 +87,10 @@ class TrasherSettingUpdater {
 	public function update_settings( $post_id, \WP_Post $post ): int {
 
 		if ( ! $this->nonce->is_valid() ) {
+			return 0;
+		}
+
+		if ( ! $this->active_post_types->includes( $post->post_type ) ) {
 			return 0;
 		}
 

--- a/src/Module/Trasher/TrasherSettingView.php
+++ b/src/Module/Trasher/TrasherSettingView.php
@@ -18,6 +18,11 @@ use function Inpsyde\MultilingualPress\nonce_field;
 class TrasherSettingView {
 
 	/**
+	 * @var ActivePostTypes
+	 */
+	private $active_post_types;
+
+	/**
 	 * @var Nonce
 	 */
 	private $nonce;
@@ -28,18 +33,13 @@ class TrasherSettingView {
 	private $setting_repository;
 
 	/**
-	 * @var ActivePostTypes
-	 */
-	private $active_post_types;
-
-	/**
 	 * Constructor. Sets up the properties.
 	 *
 	 * @since 3.0.0
 	 *
 	 * @param TrasherSettingRepository  $setting_repository Trasher setting repository object.
 	 * @param Nonce                     $nonce              Nonce object.
-     * @param ActivePostTypes           $active_post_types  ActivePostTypes object.
+     * @param ActivePostTypes           $active_post_types  Active post types storage object.
 	 */
 	public function __construct(
         TrasherSettingRepository $setting_repository,
@@ -66,7 +66,7 @@ class TrasherSettingView {
 	 */
 	public function render( \WP_Post $post ) {
 
-		if ( ! $this->active_post_types->includes( $post->post_type ) ) {
+		if ( ! $this->active_post_types->includes( (string) $post->post_type ) ) {
 			return;
 		}
 

--- a/src/Module/Trasher/TrasherSettingView.php
+++ b/src/Module/Trasher/TrasherSettingView.php
@@ -37,9 +37,9 @@ class TrasherSettingView {
 	 *
 	 * @since 3.0.0
 	 *
-	 * @param TrasherSettingRepository  $setting_repository Trasher setting repository object.
-	 * @param Nonce                     $nonce              Nonce object.
-     * @param ActivePostTypes           $active_post_types  Active post types storage object.
+	 * @param TrasherSettingRepository $setting_repository Trasher setting repository object.
+	 * @param Nonce                    $nonce              Nonce object.
+	 * @param ActivePostTypes          $active_post_types  Active post types storage object.
 	 */
 	public function __construct(
         TrasherSettingRepository $setting_repository,

--- a/src/Module/Trasher/TrasherSettingView.php
+++ b/src/Module/Trasher/TrasherSettingView.php
@@ -5,6 +5,7 @@ declare( strict_types = 1 );
 namespace Inpsyde\MultilingualPress\Module\Trasher;
 
 use Inpsyde\MultilingualPress\Common\Nonce\Nonce;
+use Inpsyde\MultilingualPress\Translation\Post\ActivePostTypes;
 
 use function Inpsyde\MultilingualPress\nonce_field;
 
@@ -27,18 +28,30 @@ class TrasherSettingView {
 	private $setting_repository;
 
 	/**
+	 * @var ActivePostTypes
+	 */
+	private $active_post_types;
+
+	/**
 	 * Constructor. Sets up the properties.
 	 *
 	 * @since 3.0.0
 	 *
-	 * @param TrasherSettingRepository $setting_repository Trasher setting repository object.
-	 * @param Nonce                    $nonce              Nonce object.
+	 * @param TrasherSettingRepository  $setting_repository Trasher setting repository object.
+	 * @param Nonce                     $nonce              Nonce object.
+     * @param ActivePostTypes           $active_post_types  ActivePostTypes object.
 	 */
-	public function __construct( TrasherSettingRepository $setting_repository, Nonce $nonce ) {
+	public function __construct(
+        TrasherSettingRepository $setting_repository,
+        Nonce $nonce,
+        ActivePostTypes $active_post_types
+    ) {
 
 		$this->setting_repository = $setting_repository;
 
 		$this->nonce = $nonce;
+
+		$this->active_post_types = $active_post_types;
 	}
 
 	/**
@@ -52,6 +65,10 @@ class TrasherSettingView {
 	 * @return void
 	 */
 	public function render( \WP_Post $post ) {
+
+		if ( ! $this->active_post_types->includes( $post->post_type ) ) {
+			return;
+		}
 
 		$id = 'mlp-trasher';
 		?>


### PR DESCRIPTION
<!--
Thanks for contributing&mdash;you rock!

Please note:
- These comments won't show up when you submit the pull request.
- Please make sure your changes respect the WordPress Coding Standards:
  - https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- In case you introduced a new action or filter hook, please also include inline documentation:
  - https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/
- Please create tests, if you can.
-->

This pull request fixes issue #215.

#### What's Included in This Pull Request

*  Make Trasher module act on activated post types only.
