### PR TITLE
Make getting redirect options more flexible

### DIFF
--- a/src/inc/redirect/Mlp_Language_Negotiation.php
+++ b/src/inc/redirect/Mlp_Language_Negotiation.php
@@ -58,9 +58,9 @@ class Mlp_Language_Negotiation implements Mlp_Language_Negotiation_Interface {
 	 * @return array
 	 */
 	public function get_redirect_match( $args = array() ) {
-		$translations = $this->language_api->get_translations(
-			array_merge( array( 'include_base' => TRUE ), $args )
-		);
+		$translations = $this->language_api->get_translations( array_merge( array(
+			'include_base' => TRUE,
+		), $args ) );
 
 		if ( empty ( $translations ) )
 			return $this->get_fallback_match();

--- a/src/inc/redirect/Mlp_Language_Negotiation.php
+++ b/src/inc/redirect/Mlp_Language_Negotiation.php
@@ -59,7 +59,7 @@ class Mlp_Language_Negotiation implements Mlp_Language_Negotiation_Interface {
 	 */
 	public function get_redirect_match( $args = array() ) {
 		$translations = $this->language_api->get_translations(
-			wp_parse_args( $args, array( 'include_base' => true ) )
+			array_merge( array( 'include_base' => TRUE ), $args )
 		);
 
 		if ( empty ( $translations ) )
@@ -114,7 +114,7 @@ class Mlp_Language_Negotiation implements Mlp_Language_Negotiation_Interface {
 			'url'               => '',
 			'language'          => '',
 			'site_id'           => 0,
-			'target_content_id' => 0,
+			'content_id' => 0,
 		);
 	}
 
@@ -149,7 +149,7 @@ class Mlp_Language_Negotiation implements Mlp_Language_Negotiation_Interface {
 			'url'               => $url,
 			'language'          => $language->get_name( 'http' ),
 			'site_id'           => $site_id,
-			'target_content_id' => $translation->get_target_content_id(),
+			'content_id' => $translation->get_target_content_id(),
 		);
 	}
 

--- a/src/inc/redirect/Mlp_Language_Negotiation.php
+++ b/src/inc/redirect/Mlp_Language_Negotiation.php
@@ -57,7 +57,7 @@ class Mlp_Language_Negotiation implements Mlp_Language_Negotiation_Interface {
 	 *
 	 * @return array
 	 */
-	public function get_redirect_match( $args = array() ) {
+	public function get_redirect_match( array $args = array() ) {
 		$translations = $this->language_api->get_translations( array_merge( array(
 			'include_base' => TRUE,
 		), $args ) );

--- a/src/inc/redirect/Mlp_Language_Negotiation.php
+++ b/src/inc/redirect/Mlp_Language_Negotiation.php
@@ -53,12 +53,13 @@ class Mlp_Language_Negotiation implements Mlp_Language_Negotiation_Interface {
 	}
 
 	/**
+	 * @param array $args
+	 *
 	 * @return array
 	 */
-	public function get_redirect_match() {
-
+	public function get_redirect_match( $args = array() ) {
 		$translations = $this->language_api->get_translations(
-			array ( 'include_base' => TRUE )
+			wp_parse_args($args, array ( 'include_base' => TRUE ))
 		);
 
 		if ( empty ( $translations ) )
@@ -109,10 +110,11 @@ class Mlp_Language_Negotiation implements Mlp_Language_Negotiation_Interface {
 	private function get_fallback_match() {
 
 		return array (
-			'priority' => 0,
-			'url'      => '',
-			'language' => '',
-			'site_id'  => 0
+			'priority'          => 0,
+			'url'               => '',
+			'language'          => '',
+			'site_id'           => 0,
+			'target_content_id' => 0,
 		);
 	}
 
@@ -143,10 +145,11 @@ class Mlp_Language_Negotiation implements Mlp_Language_Negotiation_Interface {
 
 		$combined_value   = $language->get_priority() * $user_priority;
 		$possible[]       = array (
-			'priority' => $combined_value,
-			'url'      => $url,
-			'language' => $language->get_name( 'http' ),
-			'site_id'  => $site_id
+			'priority'          => $combined_value,
+			'url'               => $url,
+			'language'          => $language->get_name( 'http' ),
+			'site_id'           => $site_id,
+			'target_content_id' => $translation->get_target_content_id(),
 		);
 	}
 

--- a/src/inc/redirect/Mlp_Language_Negotiation.php
+++ b/src/inc/redirect/Mlp_Language_Negotiation.php
@@ -59,7 +59,7 @@ class Mlp_Language_Negotiation implements Mlp_Language_Negotiation_Interface {
 	 */
 	public function get_redirect_match( $args = array() ) {
 		$translations = $this->language_api->get_translations(
-			wp_parse_args($args, array ( 'include_base' => TRUE ))
+			wp_parse_args( $args, array( 'include_base' => true ) )
 		);
 
 		if ( empty ( $translations ) )

--- a/src/inc/redirect/Mlp_Language_Negotiation.php
+++ b/src/inc/redirect/Mlp_Language_Negotiation.php
@@ -110,10 +110,10 @@ class Mlp_Language_Negotiation implements Mlp_Language_Negotiation_Interface {
 	private function get_fallback_match() {
 
 		return array (
-			'priority'          => 0,
-			'url'               => '',
-			'language'          => '',
-			'site_id'           => 0,
+			'priority'   => 0,
+			'url'        => '',
+			'language'   => '',
+			'site_id'    => 0,
 			'content_id' => 0,
 		);
 	}
@@ -145,10 +145,10 @@ class Mlp_Language_Negotiation implements Mlp_Language_Negotiation_Interface {
 
 		$combined_value   = $language->get_priority() * $user_priority;
 		$possible[]       = array (
-			'priority'          => $combined_value,
-			'url'               => $url,
-			'language'          => $language->get_name( 'http' ),
-			'site_id'           => $site_id,
+			'priority'   => $combined_value,
+			'url'        => $url,
+			'language'   => $language->get_name( 'http' ),
+			'site_id'    => $site_id,
 			'content_id' => $translation->get_target_content_id(),
 		);
 	}

--- a/src/inc/redirect/Mlp_Language_Negotiation_Interface.php
+++ b/src/inc/redirect/Mlp_Language_Negotiation_Interface.php
@@ -15,5 +15,5 @@ interface Mlp_Language_Negotiation_Interface {
 	 *
 	 * @return string
 	 */
-	public function get_redirect_match( $args = array() );
+	public function get_redirect_match( array $args = array() );
 }

--- a/src/inc/redirect/Mlp_Language_Negotiation_Interface.php
+++ b/src/inc/redirect/Mlp_Language_Negotiation_Interface.php
@@ -11,7 +11,9 @@
 interface Mlp_Language_Negotiation_Interface {
 
 	/**
+	 * @param array $args
+	 *
 	 * @return string
 	 */
-	public function get_redirect_match();
+	public function get_redirect_match( $args = array() );
 }


### PR DESCRIPTION
<!--
Thanks for contributing&mdash;you rock!

Please note:
- These comments won't show up when you submit the pull request.
- Please make sure your changes respect the WordPress Coding Standards:
  - https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- In case you introduced a new action or filter hook, please also include inline documentation:
  - https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/
- Please create tests, if you can.
-->

I'm currently trying to fetch meta data of a translated version of a post. 
 <details>
<summary>I'm using an instance of the MLP_Language_Negotiation for this.</summary>

``` PHP
$validator                     = new \Mlp_Language_Header_Validator();
$parser                        = new \Mlp_Accept_Header_Parser( $validator );
$api                           = apply_filters( 'mlp_language_api', null );
// ...
$language_negotiation_instance = new \Mlp_Language_Negotiation( $api, $parser );
```
</details>

With the Language_negotiation I get the best matching translation for a page, which is not the page I'm currently on), for which I want to fetch meta data. 

#### What's Included in This Pull Request

* Adds the `target_content_id` to the redirect matches so it can be stored or used in API calls.
* Adds the possibility to pass args to `get_redirect_match` (in my case to fetch the redirect matches for any post, not just the current page)
