### PR TITLE
Refactor post translation setting

### DIFF
--- a/src/Translation/Post/MetaBox/TranslationMetadataUpdater.php
+++ b/src/Translation/Post/MetaBox/TranslationMetadataUpdater.php
@@ -147,7 +147,7 @@ final class TranslationMetadataUpdater implements PostMetaUpdater {
 				'post_type'   => $this->save_context[ SourcePostSaveContext::POST_TYPE ],
 				'post_status' => 'draft',
 				'meta_input'  => [
-					PostsRepository::META_KEY => false,
+					PostsRepository::META_KEY => PostsRepository::META_VALUE_UNTRANSLATED,
 				],
 			] );
 		}

--- a/src/Translation/Post/MetaBox/TranslationMetadataUpdater.php
+++ b/src/Translation/Post/MetaBox/TranslationMetadataUpdater.php
@@ -9,6 +9,7 @@ use Inpsyde\MultilingualPress\Common\Admin\MetaBox\MetadataUpdater;
 use Inpsyde\MultilingualPress\Common\Admin\MetaBox\Post\PostMetaUpdater;
 use Inpsyde\MultilingualPress\Common\HTTP\ServerRequest;
 use Inpsyde\MultilingualPress\Translation\Post\ActivePostTypes;
+use Inpsyde\MultilingualPress\Widget\Dashboard\UntranslatedPosts\PostsRepository;
 
 /**
  * Metadata updater implementation for post translation.
@@ -145,6 +146,9 @@ final class TranslationMetadataUpdater implements PostMetaUpdater {
 			$this->remote_post = new \WP_Post( (object) [
 				'post_type'   => $this->save_context[ SourcePostSaveContext::POST_TYPE ],
 				'post_status' => 'draft',
+				'meta_input'  => [
+					PostsRepository::META_KEY => false,
+				],
 			] );
 		}
 

--- a/src/Widget/Dashboard/UntranslatedPosts/PostsRepository.php
+++ b/src/Widget/Dashboard/UntranslatedPosts/PostsRepository.php
@@ -29,6 +29,15 @@ interface PostsRepository {
 	const META_KEY = '_post_is_translated';
 
 	/**
+	 * Meta value used for the "untranslated" translation status.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @var string
+	 */
+	const META_VALUE_UNTRANSLATED = 'untranslated';
+
+	/**
 	 * Returns all untranslated posts for the current site.
 	 *
 	 * @since 3.0.0

--- a/src/Widget/Dashboard/UntranslatedPosts/TypeSafePostsRepository.php
+++ b/src/Widget/Dashboard/UntranslatedPosts/TypeSafePostsRepository.php
@@ -79,9 +79,7 @@ final class TypeSafePostsRepository implements PostsRepository {
 
 		$post_id = $post_id ?: (int) get_the_ID();
 
-		$value = get_post_meta( $post_id, PostsRepository::META_KEY, true );
-
-		return false === $value || $value;
+		return PostsRepository::META_VALUE_UNTRANSLATED !== get_post_meta( $post_id, PostsRepository::META_KEY, true );
 	}
 
 	/**
@@ -96,6 +94,10 @@ final class TypeSafePostsRepository implements PostsRepository {
 	 */
 	public function update_post( int $post_id, bool $value ): bool {
 
-		return (bool) update_post_meta( $post_id, PostsRepository::META_KEY, (bool) $value );
+		return (bool) update_post_meta(
+			$post_id,
+			PostsRepository::META_KEY,
+			$value ?: PostsRepository::META_VALUE_UNTRANSLATED
+		);
 	}
 }

--- a/src/Widget/Dashboard/UntranslatedPosts/TypeSafePostsRepository.php
+++ b/src/Widget/Dashboard/UntranslatedPosts/TypeSafePostsRepository.php
@@ -79,7 +79,9 @@ final class TypeSafePostsRepository implements PostsRepository {
 
 		$post_id = $post_id ?: (int) get_the_ID();
 
-		return (bool) get_post_meta( $post_id, PostsRepository::META_KEY, true );
+		$value = get_post_meta( $post_id, PostsRepository::META_KEY, true );
+
+		return false === $value || $value;
 	}
 
 	/**

--- a/src/Widget/WidgetServiceProvider.php
+++ b/src/Widget/WidgetServiceProvider.php
@@ -171,17 +171,21 @@ final class WidgetServiceProvider implements BootstrappableServiceProvider {
 
 		$container['multilingualpress.untranslated_posts_dashboard_widget']->register();
 
-		add_action(
-			'post_submitbox_misc_actions',
-			[ $container['multilingualpress.translation_completed_setting_view'], 'render' ]
-		);
+		global $pagenow;
 
-		add_action(
-			'save_post',
-			[ $container['multilingualpress.translation_completed_setting_updater'], 'update_setting' ],
-			10,
-			2
-		);
+		if ( 'post-new.php' !== $pagenow ) {
+			add_action(
+				'post_submitbox_misc_actions',
+				[ $container['multilingualpress.translation_completed_setting_view'], 'render' ]
+			);
+
+			add_action(
+				'save_post',
+				[ $container['multilingualpress.translation_completed_setting_updater'], 'update_setting' ],
+				10,
+				2
+			);
+		}
 	}
 
 	/**


### PR DESCRIPTION
This pull request refactor post translation setting behaviour.

#### What's Included in This Pull Request

* Only show the checkbox for existing posts (and not when you are just about to create a new post).
* Don't only store the value for the post you saved, but also for remote posts when you **initially** create them (with value `false`, of course).