### PR TITLE
Avoid error from STRICT_TRANS_TABLES in @@sqlmode

### DIFF
--- a/src/inc/db/Mlp_Db_Languages_Schema.php
+++ b/src/inc/db/Mlp_Db_Languages_Schema.php
@@ -49,7 +49,7 @@ class Mlp_Db_Languages_Schema implements Mlp_Db_Schema_Interface {
 			'ID'           => 'bigint unsigned NOT NULL auto_increment',
 			'english_name' => 'tinytext',
 			'native_name'  => 'tinytext',
-			'custom_name'  => 'tinytext NOT NULL',
+			'custom_name'  => 'tinytext NOT NULL DEFAULT \'\'',
 			// BOOL was added in MyQL 5.0.3, but WordPress requires just 5.0.0
 			'is_rtl'       => 'tinyint(1) unsigned DEFAULT 0',
 			// Could be de-DE-1901 or something more sophisticated


### PR DESCRIPTION
This pull request fixes issue #302.

#### What's Included in This Pull Request
Added a default value of an empty string to `custom_name` column in `mlp_languages` so that when https://github.com/inpsyde/MultilingualPress/blob/938d2bdde9db22087b19317d84b0aef1e10c126f/src/inc/db/Mlp_Db_Installer.php#L107 is called, it doesn't error out and not insert the default languages from https://github.com/inpsyde/MultilingualPress/blob/b0455cffcc4891d2f2e713add9c69bf59461229d/src/inc/db/Mlp_Db_Languages_Schema.php#L104