### PR TITLE
Fix getting translations when base site has no relationships

### DIFF
--- a/src/inc/language-api/Mlp_Language_Api.php
+++ b/src/inc/language-api/Mlp_Language_Api.php
@@ -174,7 +174,7 @@ class Mlp_Language_Api implements Mlp_Language_Api_Interface {
 			"SELECT `{$field}`
 			FROM `{$this->table_name}`
 			WHERE `http_name` = %s
-			ORDER BY `priority` DESC 
+			ORDER BY `priority` DESC
 			LIMIT 1",
 			$iso
 		);
@@ -654,12 +654,12 @@ WHERE `http_name` IN( $values )";
 
 		$sites = $this->site_relations->get_related_sites( $site_id );
 
-		if ( empty( $sites ) ) {
-			return array();
-		}
-
 		if ( $include_base ) {
 			$sites[] = (int) $site_id;
+		}
+
+		if ( empty( $sites ) ) {
+			return array();
 		}
 
 		return $sites;


### PR DESCRIPTION
<!--
Thanks for contributing to MultilingualPress (MLP)&mdash;you rock!

Please note:
- These comments won't show up when you submit the pull request.
- Please make sure your changes respect the WordPress Coding Standards:
  - https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- In case you introduced a new action or filter hook, please also include inline documentation:
  - https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/
- In case you added or changed assets, please make sure you did this in the resources/ folder.
- Please create unit tests, if you can:
  - https://github.com/inpsyde/multilingual-press/tree/master/tests
- If you Grunt installed, please run `grunt pre-commit` before committing your changes.
-->

This pull request fixes issue #304.

#### What's Included in This Pull Request
* Populate related sites with base site before checking for an empty state
