### PR TITLE
Cache the call to get all languages.

### DIFF
--- a/src/inc/language-api/Mlp_Language_Api.php
+++ b/src/inc/language-api/Mlp_Language_Api.php
@@ -43,9 +43,9 @@ class Mlp_Language_Api implements Mlp_Language_Api_Interface {
 	private $content_relations;
 
 	/**
-	 * @var array
+	 * @var string
 	 */
-	private $language_data_from_db = array();
+	private $cache_group = 'mlp';
 
 	/**
 	 * Constructor.
@@ -485,11 +485,14 @@ class Mlp_Language_Api implements Mlp_Language_Api_Interface {
 	 */
 	private function get_all_language_data() {
 
-		if ( ! empty( $this->language_data_from_db ) ) {
-			return $this->language_data_from_db;
-		}
-
 		$languages = (array) get_site_option( 'inpsyde_multilingual', array() );
+
+		$cache_key = 'mlp_all_language_data_' . md5( serialize( $languages ) );
+		$cache = wp_cache_get( $cache_key, $this->cache_group );
+
+		if ( is_array( $cache ) ) {
+			return $cache;
+		}
 
 		if ( empty( $languages ) ) {
 			return array();
@@ -541,7 +544,7 @@ WHERE `http_name` IN( $values )";
 			}
 		}
 
-		$this->language_data_from_db = $languages;
+		wp_cache_set( $cache_key, $languages, $this->cache_group );
 
 		return $languages;
 	}


### PR DESCRIPTION
<!--
Thanks for contributing to MultilingualPress (MLP)&mdash;you rock!

Please note:
- These comments won't show up when you submit the pull request.
- Please make sure your changes respect the WordPress Coding Standards:
  - https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- In case you introduced a new action or filter hook, please also include inline documentation:
  - https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/
- In case you added or changed assets, please make sure you did this in the resources/ folder.
- Please create unit tests, if you can:
  - https://github.com/inpsyde/multilingual-press/tree/master/tests
- If you Grunt installed, please run `grunt pre-commit` before committing your changes.
-->

This pull request (partially) fixes issue #297 .

#### What's Included in This Pull Request

Although the result was being memoised and the query is relatively
light, it's still a query which would be called for each request which
can cause problems on large sites with large amounts of traffic.

This change will cache the languages indefinitely until a language is
changed on any site. It uses an md5 of the serialized array of languages
to do this.

This should stop a query being run on each request and addresses part of https://github.com/inpsyde/MultilingualPress/issues/297

I appreciate you've likely addressed this in v3 but some of us haven't quite upgraded yet :)
